### PR TITLE
First Timeline Semaphore use

### DIFF
--- a/auto_vk_toolkit/include/configure_and_compose.hpp
+++ b/auto_vk_toolkit/include/configure_and_compose.hpp
@@ -186,6 +186,7 @@ namespace avk
 			.setShaderUniformTexelBufferArrayDynamicIndexing(VK_TRUE)
 			.setShaderStorageTexelBufferArrayDynamicIndexing(VK_TRUE)
 			.setDescriptorIndexing(VK_TRUE)
+			.setTimelineSemaphore(VK_TRUE)
 			.setBufferDeviceAddress(VK_FALSE);
 
 #if VK_HEADER_VERSION >= 162

--- a/auto_vk_toolkit/include/context_vulkan.hpp
+++ b/auto_vk_toolkit/include/context_vulkan.hpp
@@ -167,6 +167,10 @@ namespace avk
 		avk::command_buffer record_and_submit(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 
 		avk::semaphore record_and_submit_with_semaphore(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, avk::stage::pipeline_stage_flags aSrcSignalStage, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+		
+		avk::semaphore record_and_submit_with_timeline_semaphore(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, avk::stage::pipeline_stage_flags aSrcSignalStage, uint64_t aSignalValue, uint64_t aInitialValue = 0, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
+
+		void record_and_submit_with_timeline_semaphore(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, avk::semaphore_signal_info aSignalInfo, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 
 		avk::fence record_and_submit_with_fence(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 		

--- a/auto_vk_toolkit/include/context_vulkan.hpp
+++ b/auto_vk_toolkit/include/context_vulkan.hpp
@@ -167,9 +167,23 @@ namespace avk
 		avk::command_buffer record_and_submit(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 
 		avk::semaphore record_and_submit_with_semaphore(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, avk::stage::pipeline_stage_flags aSrcSignalStage, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
-		
+		/** \brief Records and submits commands to a queue together with a newly created timeline semaphore, which is signalled upon completion.
+		* \param aRecordedCommandsAndSyncInstructions	List of commands to record and submit.
+		* \param aQueue									The queue to submit the commands to.
+		* \param aSrcSignalStage						Defines in which stage it is safe to signal the created timeline semaphore.
+		* \param aSignalValue							The value to SIGNAL the timeline semaphore to.
+		* \param aInitialValue				(optional)	The value to INITIALIZE the newly created timeline semaphore with.
+		* \param aUsageFlags				(optional)	CommandBuffer usage flags.
+		* \return The newly created timeline semaphore.
+		*/
 		avk::semaphore record_and_submit_with_timeline_semaphore(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, avk::stage::pipeline_stage_flags aSrcSignalStage, uint64_t aSignalValue, uint64_t aInitialValue = 0, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 
+		/** \brief Records and submits commands to a queue together with the given timeline semaphore, which is signalled upon completion.
+		* \param aRecordedCommandsAndSyncInstructions	List of commands to record and submit.
+		* \param aQueue									The queue to submit the commands to.
+		* \param aSignalInfo							Used to specify the timeline semaphore, after which stage it's supposed to be triggered, and to which value it should be set.
+		* \param aUsageFlags				(optional)	CommandBuffer usage flags.
+		*/
 		void record_and_submit_with_timeline_semaphore(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, avk::semaphore_signal_info aSignalInfo, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);
 
 		avk::fence record_and_submit_with_fence(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, vk::CommandBufferUsageFlags aUsageFlags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit);

--- a/auto_vk_toolkit/src/context_vulkan.cpp
+++ b/auto_vk_toolkit/src/context_vulkan.cpp
@@ -442,6 +442,27 @@ namespace avk
 		return sem;
 	}
 
+	avk::semaphore context_vulkan::record_and_submit_with_timeline_semaphore(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, avk::stage::pipeline_stage_flags aSrcSignalStage, uint64_t aSignalValue, uint64_t aInitialValue, vk::CommandBufferUsageFlags aUsageFlags) {
+		auto sem = create_timeline_semaphore(aInitialValue);
+		record_and_submit_with_timeline_semaphore(aRecordedCommandsAndSyncInstructions, aQueue, aSrcSignalStage >> sem | aSignalValue, aUsageFlags);
+		return sem;
+	}
+
+	void context_vulkan::record_and_submit_with_timeline_semaphore(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, avk::semaphore_signal_info aSignalInfo, vk::CommandBufferUsageFlags aUsageFlags) {
+		auto& cmdPool = get_command_pool_for_single_use_command_buffers(aQueue);
+		auto cmdBfr = cmdPool->alloc_command_buffer(aUsageFlags);
+		
+
+		record(std::move(aRecordedCommandsAndSyncInstructions))
+			.into_command_buffer(cmdBfr)
+			.then_submit_to(aQueue)
+			.signaling_upon_completion(aSignalInfo)
+			.submit();
+
+		aSignalInfo.mSignalSemaphore.get().handle_lifetime_of(std::move(cmdBfr));
+		// TODO we probably need another way to handle the lifetime of resources since timeline semaphores aren't single use ==> live longer
+	}
+
 	avk::fence context_vulkan::record_and_submit_with_fence(std::vector<avk::recorded_commands_t> aRecordedCommandsAndSyncInstructions, const avk::queue& aQueue, vk::CommandBufferUsageFlags aUsageFlags)
 	{
 		auto& cmdPool = get_command_pool_for_single_use_command_buffers(aQueue);

--- a/examples/model_loader/source/model_loader.cpp
+++ b/examples/model_loader/source/model_loader.cpp
@@ -101,15 +101,15 @@ public: // v== avk::invokee overrides which will be invoked by the framework ==v
 			auto idxFillCmd = newElement.mIndexBuffer->fill(newElement.mIndices.data(), 0);
 
 			// Submit all the fill commands to the queue:
-			auto fence = avk::context().record_and_submit_with_fence({
+			auto timelineSemaphore = avk::context().record_and_submit_with_timeline_semaphore({
 				std::move(posFillCmd),
 				std::move(tcoFillCmd),
 				std::move(nrmFillCmd),
 				std::move(idxFillCmd)
 				// ^ No need for any synchronization in-between, because the commands do not depend on each other.
-			}, *mQueue);
+				}, * mQueue, { vk::PipelineStageFlagBits2::eAllTransfer }, 1);
 			// Wait on the host until the device is done:
-			fence->wait_until_signalled();
+			timelineSemaphore->wait_until_signalled(1);
 		}
 
 		// For all the different materials, transfer them in structs which are well
@@ -131,11 +131,11 @@ public: // v== avk::invokee overrides which will be invoked by the framework ==v
 		);
 
 		// Submit the commands material commands and the materials buffer fill to the device:
-		auto matFence = avk::context().record_and_submit_with_fence({
+		auto matTSemaphore = avk::context().record_and_submit_with_timeline_semaphore({
 			std::move(materialCommands),
 			mMaterialBuffer->fill(gpuMaterials.data(), 0)
-		}, *mQueue);
-		matFence->wait_until_signalled();
+		}, *mQueue, {vk::PipelineStageFlagBits2::eAllCommands}, 1);
+		matTSemaphore->wait_until_signalled(1);
 
 		// Create a buffer for the transformation matrices in a host coherent memory region (one for each frame in flight):
 		for (int i = 0; i < 10; ++i) { // Up to 10 concurrent frames can be configured through the UI.


### PR DESCRIPTION
The first step towards full timeline semaphore support. Related Issue: #45 

Changes:
* Adds and implements `context_vulkan::record_and_submit_with_timeline_semaphore`
* Replaces fences in `model_loader` example with timeline semaphores.