### PR TITLE
Removed #include <auto_vk_toolkit.hpp> from many files.

### DIFF
--- a/auto_vk_toolkit/include/concurrent_frames_count_changed_event.hpp
+++ b/auto_vk_toolkit/include/concurrent_frames_count_changed_event.hpp
@@ -1,5 +1,5 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
+#include "window.hpp"
 #include "event.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/include/context_generic_glfw_types.hpp
+++ b/auto_vk_toolkit/include/context_generic_glfw_types.hpp
@@ -1,6 +1,5 @@
 #pragma once
-//#include <auto_vk_toolkit.hpp>
-
+#include "avk/avk_error.hpp"
 #include <GLFW/glfw3.h>
 
 namespace avk

--- a/auto_vk_toolkit/include/context_vulkan.hpp
+++ b/auto_vk_toolkit/include/context_vulkan.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
 
 #include "context_generic_glfw.hpp"
 #include "settings.hpp"

--- a/auto_vk_toolkit/include/conversion_utils.hpp
+++ b/auto_vk_toolkit/include/conversion_utils.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
 
 namespace avk
 {

--- a/auto_vk_toolkit/include/input_buffer.hpp
+++ b/auto_vk_toolkit/include/input_buffer.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
-
 #include "key_code.hpp"
 #include "key_state.hpp"
 

--- a/auto_vk_toolkit/include/math_utils.hpp
+++ b/auto_vk_toolkit/include/math_utils.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
 
 namespace avk
 {

--- a/auto_vk_toolkit/include/model_types.hpp
+++ b/auto_vk_toolkit/include/model_types.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
 
 namespace avk
 {

--- a/auto_vk_toolkit/include/settings.hpp
+++ b/auto_vk_toolkit/include/settings.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
 
 namespace avk
 {

--- a/auto_vk_toolkit/include/transform.hpp
+++ b/auto_vk_toolkit/include/transform.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
 
 namespace avk
 {

--- a/auto_vk_toolkit/include/vk_convenience_functions.hpp
+++ b/auto_vk_toolkit/include/vk_convenience_functions.hpp
@@ -1,5 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
 
 namespace avk
 {

--- a/auto_vk_toolkit/include/window.hpp
+++ b/auto_vk_toolkit/include/window.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
-
 #include "window_base.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/include/window_base.hpp
+++ b/auto_vk_toolkit/include/window_base.hpp
@@ -1,6 +1,4 @@
 #pragma once
-#include <auto_vk_toolkit.hpp>
-
 #include "cursor.hpp"
 #include "context_generic_glfw_types.hpp"
 

--- a/auto_vk_toolkit/src/animation.cpp
+++ b/auto_vk_toolkit/src/animation.cpp
@@ -1,4 +1,3 @@
-#include <auto_vk_toolkit.hpp>
 #include <glm/gtx/quaternion.hpp>
 
 #include "animation.hpp"

--- a/auto_vk_toolkit/src/bezier_curve.cpp
+++ b/auto_vk_toolkit/src/bezier_curve.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "bezier_curve.hpp"
 #include "math_utils.hpp"
 

--- a/auto_vk_toolkit/src/catmull_rom_spline.cpp
+++ b/auto_vk_toolkit/src/catmull_rom_spline.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "catmull_rom_spline.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/composition.cpp
+++ b/auto_vk_toolkit/src/composition.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "composition.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/context_generic_glfw.cpp
+++ b/auto_vk_toolkit/src/context_generic_glfw.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "composition_interface.hpp"
 #include "context_vulkan.hpp"
 #include "context_generic_glfw.hpp"

--- a/auto_vk_toolkit/src/context_vulkan.cpp
+++ b/auto_vk_toolkit/src/context_vulkan.cpp
@@ -1,4 +1,3 @@
-#include <auto_vk_toolkit.hpp>
 #include <set>
 #include "context_vulkan.hpp"
 #include "context_generic_glfw.hpp"

--- a/auto_vk_toolkit/src/cp_interpolation.cpp
+++ b/auto_vk_toolkit/src/cp_interpolation.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "cp_interpolation.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/cubic_uniform_b_spline.cpp
+++ b/auto_vk_toolkit/src/cubic_uniform_b_spline.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "cubic_uniform_b_spline.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/files_changed_event.cpp
+++ b/auto_vk_toolkit/src/files_changed_event.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "files_changed_event.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/imgui_manager.cpp
+++ b/auto_vk_toolkit/src/imgui_manager.cpp
@@ -1,4 +1,3 @@
-#include <auto_vk_toolkit.hpp>
 #ifndef IMGUI_DEFINE_MATH_OPERATORS
 #define IMGUI_DEFINE_MATH_OPERATORS
 #endif

--- a/auto_vk_toolkit/src/log.cpp
+++ b/auto_vk_toolkit/src/log.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #if defined(_WIN32) && defined (_DEBUG) && defined (PRINT_STACKTRACE)
 #include <Windows.h>
 #include <DbgHelp.h>

--- a/auto_vk_toolkit/src/math_utils.cpp
+++ b/auto_vk_toolkit/src/math_utils.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "math_utils.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/quadratic_uniform_b_spline.cpp
+++ b/auto_vk_toolkit/src/quadratic_uniform_b_spline.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "quadratic_uniform_b_spline.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/updater.cpp
+++ b/auto_vk_toolkit/src/updater.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "updater.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/window.cpp
+++ b/auto_vk_toolkit/src/window.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "context_vulkan.hpp"
 
 namespace avk

--- a/auto_vk_toolkit/src/window_base.cpp
+++ b/auto_vk_toolkit/src/window_base.cpp
@@ -1,5 +1,3 @@
-#include <auto_vk_toolkit.hpp>
-
 #include "context_vulkan.hpp"
 
 namespace avk


### PR DESCRIPTION
We don't really need those `#include <auto_vk_toolkit.hpp>`, do we?