### PR TITLE
Change window subpass dependencies to use ALL_GRAPHICS_BIT instead of ALL_COMMANDS_BIT

### DIFF
--- a/auto_vk_toolkit/src/window.cpp
+++ b/auto_vk_toolkit/src/window.cpp
@@ -810,11 +810,11 @@ namespace avk
 			auto newRenderPass = context().create_renderpass(renderpassAttachments, {
 				// We only create one subpass here => create default dependencies as per specification chapter 8.1) Render Pass Creation:
 				avk::subpass_dependency{avk::subpass::external >> avk::subpass::index(0),
-					avk::stage::none  >> avk::stage::all_commands,
+					avk::stage::none  >> avk::stage::all_graphics,
 					avk::access::none >> avk::access::input_attachment_read | avk::access::color_attachment_read | avk::access::color_attachment_write | avk::access::depth_stencil_attachment_read | avk::access::depth_stencil_attachment_write
 				},
 				avk::subpass_dependency{avk::subpass::index(0) >> avk::subpass::external,
-					avk::stage::all_commands                                                          >> avk::stage::none,
+					avk::stage::all_graphics                                                          >> avk::stage::none,
 					avk::access::color_attachment_write | avk::access::depth_stencil_attachment_write >> avk::access::none
 				}
 			});


### PR DESCRIPTION
The window renderpass regeneration code creates subpass dependencies based on ALL_COMMANDS_BIT. While [the spec implies that this will be supported on any render pass](https://registry.khronos.org/vulkan/specs/1.3-extensions/man/html/VkPipelineStageFlagBits.html), when used with the example triangle app that doesn't setup any custom subpasses or dependencies, this fails with a [validation error](https://vulkan.lunarg.com/doc/view/1.3.243.0/windows/1.3-extensions/vkspec.html#VUID-VkRenderPassCreateInfo2-pDependencies-03055) as it is not supported by the pipeline. The confusion in the spec is being addressed in [this thread](https://github.com/KhronosGroup/Vulkan-Docs/issues/1020).

On a seperate note, I couldn't find the default dependencies in chapter 8.1 as mentioned in the comment above. Maybe the spec has changed?