### PR TITLE
c++20 instead of c++latest, and some more documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,21 @@ Some of its highlight-features (besides the awesome features of [_Auto-Vk_](http
 - Support for dividing meshes into [meshlets](./docs/meshlets.md) which can be rendered with task and mesh shaders.
 - Handling of bone hierarchies, supporting animation of skinned meshes.
 
+## Table of Contents
+
+- [Installation](#installation)
+  - [Visual Studio 2022](#visual-studio-2022)
+    - [Requirements](#requirements)
+    - [Setup and build instructions](#setup-and-build-instructions)
+    - [Set up your own project](#set-up-your-own-project)
+  - [CMake](#cmake)
+- [Examples](#examples)
+- [Creating a New Project](#creating-a-new-project)
+- [Resource Mangement and the Post Build Helper](#resource-mangement-and-the-post-build-helper)
+- [What's the difference between Auto-Vk-Toolkit and Auto-Vk?](#whats-the-difference-between-auto-vk-toolkit-and-auto-vk)
+- [Documentation](#documentation)
+- [FAQs, Known Issues, Troubleshooting](#faqs-known-issues-troubleshooting)
+
 # Installation
 
 *Auto-Vk-Toolkit* is ready to go with Visual Studio or CMake. If your system meets the system requirements, everything is set up to build an run right out of the box. E.g., for Visual Studio, open [`visual_studio/auto_vk_toolkit.sln`](./visual_studio/), set one of the example projects as startup project, build and run!
@@ -34,20 +49,26 @@ Some of its highlight-features (besides the awesome features of [_Auto-Vk_](http
 ## Visual Studio 2022
 A preconfigured project setup is provided for Visual Studio 2022 on Windows.
 
-Requirements:
+### Requirements
 * Windows 10 or 11
 * Visual Studio 2022 with a Windows 10 or 11 SDK installed (For detailed information about project setup and resource management please refer to [`visual_studio/README.md`](./visual_studio/README.md).)
-* A [Vulkan SDK from LunarG](https://vulkan.lunarg.com/sdk/home), optimally Vulkan SDK 1.2.141.0 or newer.          
-  Latest stable and tested version: Vulkan SDK 1.3.243.0
+* A [Vulkan SDK from LunarG](https://vulkan.lunarg.com/sdk/home), optimally Vulkan SDK 1.3.250.0 or newer.
 
-Setup and build instructions:
-* Clone this repository
-* Execute a `git submodule update --init` to pull the [_Auto-Vk_](https://github.com/cg-tuwien/Auto-Vk) framework which is added as a submodule under `auto_vk`
+### Setup and build instructions
+* Clone or download this repository
+* Execute `git submodule update --init` to pull the [_Auto-Vk_](https://github.com/cg-tuwien/Auto-Vk) framework which is added as a submodule under `auto_vk`
+* Download and install one of the latest [Vulkan SDKs for Windows](https://vulkan.lunarg.com/sdk/home#windows)! (At time of writing, the most recent version is 1.3.250.0.)
+    * Select the `Vulkan Memory Allocator header.` option so that the [Vulkan Memory Allocator](https://github.com/GPUOpen-LibrariesAndSDKs/VulkanMemoryAllocator) (VMA) library is installed. 
+    * _Note:_ VMA can be installed through the Vulkan installer or its maintenance tool (e.g., `maintenancetool.exe` on Windows) by selecting the `Vulkan Memory Allocator header.` option.
+* Download and install [Visual Studio Community 2022](https://visualstudio.microsoft.com/vs/community/), or a newer version.
+    * Select the `Desktop development with C++` workload in the installer!
+* _Recommended:_ Install the [GLSL language integration](https://marketplace.visualstudio.com/items?itemName=DanielScherzer.GLSL2022) extension for syntax highlighting in shader files!
+    * _Hint:_ Go to `Tools -> Options -> GLSL language integration`. For Vulkan shader development, either set `Live compiling` to `False` (syntax highlighting only), or set the `External compiler executable file` to, e.g., the path to `glslangValidator.exe`!
 * Open the Visual Studio solution file [`visual_studio/auto_vk_toolkit.sln`](./visual_studio/), and build the solution
 * During building, you'll recognize messages from the _Post Build Helper_ tool in Visual Studio's `Output`-tab, some popup messages, and an icon in the system tray. Please have a look at section [Resource Mangement and the Post Build Helper](#resource-mangement-and-the-post-build-helper) for additional information.
 * Several example applications are available in the solution file. Set one of them as startup project, and run.
 
-Set up your own project:
+### Set up your own project
 * To add _Auto-Vk-Toolkit_ to one of your custom repositories, you might want to add it as a GIT submodule. You could execute `git submodule add https://github.com/cg-tuwien/Auto-Vk-Toolkit.git auto_vk_toolkit` to add _Auto-Vk-Toolkit_ as submodule in directory `auto_vk_toolkit`.
 * Execute `git submodule update --init --recursive` in order to pull both, _Auto-Vk-Toolkit_ and [_Auto-Vk_](https://github.com/cg-tuwien/Auto-Vk).
 * The steps described under section [Creating a New Project](#creating-a-new-project) might be helpful for setting up a custom Visual Studio project that links against _Auto-Vk-Toolkit_.
@@ -146,9 +167,14 @@ vk::material_gpu_data`)
   * If shader files contain errors, popup messages are created displaying the error, and providing a `[->VS]` button to navigate to the line that contains the error _within_ Visual Studio.
   * By default, "Debug" and "Release" build configurations symlink resources to save space, but "Publish" build configurations deploy all required files into the target directory so that a built program can easily be transfered to another PC. No more tedious resource gathering is required in such situations since that is all handled by the Post Build Helper.
 
-# Automatic Resource-Updates
+# Documentation
 
-See: [Automatic Resource-Updates](./docs/updater.md)
+There are some documentation pages containing further information:
+- [Usage of ImGui for User Interfaces](./docs/ImGui.md), describing how to use [Dear ImGui](https://github.com/ocornut/imgui) in an _Auto-Vk-Toolkit_ project
+- [CMake](./docs/cmake.md) setup and build instructions
+- [Meshlets](./docs/meshlets.md)-specfic functionality for dividing geometry into small clusters and using them for rendering in graphics mesh pipelines (those with task and mesh shaders)
+- [Serializer](./docs/serializer.md) functionality for storing and loading resources to/from file, such as 3D models, images, or custom structs
+- [Automatic Resource-Updates](./docs/updater.md) through the `avk::updater` class, enabling shwapchain recreation and shader hot reloading
 
 # FAQs, Known Issues, Troubleshooting
 

--- a/docs/ImGui.md
+++ b/docs/ImGui.md
@@ -1,3 +1,10 @@
+# Table of Contents
+
+- [Usage of ImGui for User Interfaces](#usage-of-imgui-for-user-interfaces)
+  - [imgui_manager and Establishing Callbacks](#imgui_manager-and-establishing-callbacks)
+  - [Rendering Textures with get_or_create_texture_descriptor](#rendering-textures-with-get_or_create_texture_descriptor)
+  - [Additional Image Utils](#additional-image-utils)
+
 # Usage of ImGui for User Interfaces
 
 _Auto-Vk-Toolkit_ offers support for usage of the graphical user interface library [Dear ImGui](https://github.com/ocornut/imgui). Its headers are not included by default.

--- a/docs/cmake.md
+++ b/docs/cmake.md
@@ -1,3 +1,16 @@
+# Table of Contents
+
+- [CMake](#cmake)
+  - [CLion](#clion)
+    - [Linux: Ubuntu](#linux-ubuntu)
+    - [Windows](#windows)
+    - [CMake Options](#cmake-options)
+      - [Windows CMake build settings](#windows-cmake-build-settings)
+    - [Creating a New Project (CMake)](#creating-a-new-project-cmake)
+      - [Resource Management (Cmake)](#resource-management-cmake)
+        - [Shaders](#shaders)
+        - [Caveats](#caveats)
+
 # CMake
 
 _Auto-Vk-Toolkit_ also supports building with CMake on Linux (*GCC* or *Clang*) and Windows (*MSVC*).

--- a/docs/meshlets.md
+++ b/docs/meshlets.md
@@ -1,3 +1,13 @@
+# Table of Contents
+
+- [Meshlets](#meshlets)
+  - [Dividing Meshes into Meshlets in Auto-Vk-Toolkit](#dividing-meshes-into-meshlets-in-auto-vk-toolkit)
+    - [Using a Custom Division Function](#using-a-custom-division-function)
+      - [Example for Vertices and Indices:](#example-for-vertices-and-indices)
+      - [Example for Indices Only:](#example-for-indices-only)
+      - [Example That Uses a 3rd Party Library:](#example-that-uses-a-3rd-party-library)
+  - [Converting Into a Format for GPU Usage](#converting-into-a-format-for-gpu-usage)
+
 # Meshlets
 
 When using _graphics mesh pipelines_ with _task_ and _mesh shaders_, a typical use case is to segmented meshes into smaller segments called meshlets, and process these. These meshlets contain multiple triangles that should ideally be structured in a meaningful way in memory in order to enable efficient processing, like for example good memory and cache coherency. Meshlets of triangle meshes typically consist of relatively small packages of vertices and triangles of the original mesh geometry.

--- a/docs/serializer.md
+++ b/docs/serializer.md
@@ -1,3 +1,11 @@
+# Table of Contents
+
+- [Serializer](#serializer)
+  - [How to use](#how-to-use)
+  - [\*\_cached functions](#_cached-functions)
+      - [Available \*\_cached variants of scene and model loading functions](#available-_cached-variants-of-scene-and-model-loading-functions)
+  - [Custom type serialization](#custom-type-serialization)
+
 # Serializer
 _Auto-Vk-Toolkit_ features an object serializer to improve load times of resources like huge 3D models or ORCA scenes by serializing all the processed and ready to use data into a cache file during the first run. In further runs, the data can be directly deserialized into types and structures used by _Auto-Vk-Toolkit_ and expensive parsing and processing of huge models or scenes can be avoided.
 

--- a/docs/updater.md
+++ b/docs/updater.md
@@ -1,3 +1,15 @@
+# Table of Contents
+
+- [Automatic Resource-Updates](#automatic-resource-updates)
+  - [How to use](#how-to-use)
+    - [Code Examples](#code-examples)
+      - [Updating a graphics pipeline](#updating-a-graphics-pipeline)
+      - [Establishing an ordered update chain](#establishing-an-ordered-update-chain)
+  - [Common Use-Cases](#common-use-cases)
+  - [Notes on Swapchain recreation](#notes-on-swapchain-recreation)
+  - [General Notes](#general-notes)
+  - [Example Applications](#example-applications)
+
 # Automatic Resource-Updates
 
 _Auto-Vk-Toolkit_ features functionality to automatically update resources (like images or pipelines), or invoke callbacks after certain _events_ have occured. Currently the following event types are supported:
@@ -47,7 +59,7 @@ It is important to note that the order in which the events are evaluated is not 
 
 ### Code Examples
 
-#### Updating the graphics pipeline  
+#### Updating a graphics pipeline  
 ```
 mUpdater->on(avk::swapchain_resized_event(avk::context().main_window()), 
         avk::shader_files_changed_event(mPipeline.as_reference())

--- a/visual_studio/README.md
+++ b/visual_studio/README.md
@@ -1,3 +1,31 @@
+# Table of Contents
+
+- [Setup](#setup)
+- [Project Management with Visual Studio](#project-management-with-visual-studio)
+  - [Creating a New Project](#creating-a-new-project)
+  - [Resource Management](#resource-management)
+    - [Dependent Assets](#dependent-assets)
+    - [Known Issues and Troubleshooting w.r.t. Asset Handling](#known-issues-and-troubleshooting-wrt-asset-handling)
+      - [Build errors when adding assets](#build-errors-when-adding-assets)
+      - [Asset is not deployed because it is not saved in the Visual Studio's filters-file](#asset-is-not-deployed-because-it-is-not-saved-in-the-visual-studios-filters-file)
+  - [Post Build Helper](#post-build-helper)
+    - [Deployment of Dependent Assets](#deployment-of-dependent-assets)
+    - [Symbolic Links/Copies depending on Build Configuration](#symbolic-linkscopies-depending-on-build-configuration)
+    - [_Post Build Helper_ Troubleshooting](#post-build-helper-troubleshooting)
+      - [Build is stuck at "Going to invoke[...]MSBuild.exe" step, displayed in Visual Studio's _Output_ tab](#build-is-stuck-at-going-to-invokemsbuildexe-step-displayed-in-visual-studios-output-tab)
+      - [_Post Build Helper_ can't be built automatically/via MSBuild.exe](#post-build-helper-cant-be-built-automaticallyvia-msbuildexe)
+      - [Too few resources are being deployed](#too-few-resources-are-being-deployed)
+      - [Application could not start at first try (maybe due to missing assets or DLLs)](#application-could-not-start-at-first-try-maybe-due-to-missing-assets-or-dlls)
+      - [Error message about denied access to DLL files (DLLs are not re-deployed)](#error-message-about-denied-access-to-dll-files-dlls-are-not-re-deployed)
+      - [Slow performance when showing lists within the Post Build Helper](#slow-performance-when-showing-lists-within-the-post-build-helper)
+      - [Error message in the UI of Post Build Helper: "Could not find part of the path '...'"](#error-message-in-the-ui-of-post-build-helper-could-not-find-part-of-the-path-)
+      - [Error message in the console: `can't fopen`, or `!RUNTIME ERROR! Couldn't load image from '...'` or similar](#error-message-in-the-console-cant-fopen-or-runtime-error-couldnt-load-image-from--or-similar)
+    - [_Post Build Helper_ Settings](#post-build-helper-settings)
+
+# Setup
+
+For fundamental installation instructions and basic setup, please refer to the main [README.md](../README.md)'s [Visual Studio 2022](../README.md#visual-studio-2022) section.
+
 # Project Management with Visual Studio
 
 The Visual Studio projects can be used for resource management and there is a _Post Build Helper_ tool which handles SPIR-V compilation of shader files and deployment of resource files to the target directory. Its located under [`visual_studio/tools/executables/`](./tools/executables) and is invoked as a build step of _Auto-Vk-Toolkit_'s example applications. 

--- a/visual_studio/auto_vk_toolkit/auto_vk_toolkit.vcxproj
+++ b/visual_studio/auto_vk_toolkit/auto_vk_toolkit.vcxproj
@@ -505,7 +505,7 @@
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <RuntimeTypeInfo>true</RuntimeTypeInfo>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>

--- a/visual_studio/examples/compute_image_processing/compute_image_processing.vcxproj
+++ b/visual_studio/examples/compute_image_processing/compute_image_processing.vcxproj
@@ -175,7 +175,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/framebuffer/framebuffer.vcxproj
+++ b/visual_studio/examples/framebuffer/framebuffer.vcxproj
@@ -169,7 +169,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/hello_world/hello_world.vcxproj
+++ b/visual_studio/examples/hello_world/hello_world.vcxproj
@@ -169,7 +169,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/model_loader/model_loader.vcxproj
+++ b/visual_studio/examples/model_loader/model_loader.vcxproj
@@ -174,7 +174,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/multi_invokee_rendering/multi_invokee_rendering.vcxproj
+++ b/visual_studio/examples/multi_invokee_rendering/multi_invokee_rendering.vcxproj
@@ -169,7 +169,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/multiple_queues/multiple_queues.vcxproj
+++ b/visual_studio/examples/multiple_queues/multiple_queues.vcxproj
@@ -169,7 +169,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/orca_loader/orca_loader.vcxproj
+++ b/visual_studio/examples/orca_loader/orca_loader.vcxproj
@@ -171,7 +171,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/present_from_compute/present_from_compute.vcxproj
+++ b/visual_studio/examples/present_from_compute/present_from_compute.vcxproj
@@ -170,7 +170,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/ray_query_in_ray_tracing_shaders/ray_query_in_ray_tracing_shaders.vcxproj
+++ b/visual_studio/examples/ray_query_in_ray_tracing_shaders/ray_query_in_ray_tracing_shaders.vcxproj
@@ -172,7 +172,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/ray_tracing_custom_intersection/ray_tracing_custom_intersection.vcxproj
+++ b/visual_studio/examples/ray_tracing_custom_intersection/ray_tracing_custom_intersection.vcxproj
@@ -173,7 +173,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/ray_tracing_with_shadows_and_ao/ray_tracing_with_shadows_and_ao.vcxproj
+++ b/visual_studio/examples/ray_tracing_with_shadows_and_ao/ray_tracing_with_shadows_and_ao.vcxproj
@@ -176,7 +176,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/skinned_meshlets/skinned_meshlets.vcxproj
+++ b/visual_studio/examples/skinned_meshlets/skinned_meshlets.vcxproj
@@ -180,7 +180,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>
       </ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>

--- a/visual_studio/examples/static_meshlets/static_meshlets.vcxproj
+++ b/visual_studio/examples/static_meshlets/static_meshlets.vcxproj
@@ -175,7 +175,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>
       </ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>

--- a/visual_studio/examples/texture_cubemap/texture_cubemap.vcxproj
+++ b/visual_studio/examples/texture_cubemap/texture_cubemap.vcxproj
@@ -191,7 +191,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>

--- a/visual_studio/examples/vertex_buffers/vertex_buffers.vcxproj
+++ b/visual_studio/examples/vertex_buffers/vertex_buffers.vcxproj
@@ -169,7 +169,7 @@
       <SDLCheck>false</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <LanguageStandard>stdcpplatest</LanguageStandard>
+      <LanguageStandard>stdcpp20</LanguageStandard>
       <ForcedIncludeFiles>cg_stdafx.hpp</ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>


### PR DESCRIPTION
Should fix build not working on Visual Studio Version 17.6.5, because with that version, `c++latest` does something terrible (includes Modules headers or whatever).