### PR TITLE
renderpass() into get_renderpass()

### DIFF
--- a/auto_vk_toolkit/include/window.hpp
+++ b/auto_vk_toolkit/include/window.hpp
@@ -372,7 +372,7 @@ namespace avk
 
 		/** Gets the backbuffer's render pass
 		 */
-		[[nodiscard]] avk::renderpass renderpass() const { return mBackBufferRenderpass; }
+		[[nodiscard]] avk::renderpass get_renderpass() const { return mBackBufferRenderpass; }
 
 		/**	This is intended to be used as a command buffer lifetime handler for `avk::old_sync::with_barriers`.
 		 *	The specified frame id is the frame where the command buffer has to be guaranteed to finish

--- a/examples/hello_world/source/hello_world.cpp
+++ b/examples/hello_world/source/hello_world.cpp
@@ -25,7 +25,7 @@ public: // v== avk::invokee overrides which will be invoked by the framework ==v
 			avk::cfg::front_face::define_front_faces_to_be_clockwise(),
 			avk::cfg::viewport_depth_scissors_config::from_framebuffer(avk::context().main_window()->backbuffer_reference_at_index(0)),
 			// Just use the main window's renderpass for this pipeline:
-			avk::context().main_window()->renderpass()
+			avk::context().main_window()->get_renderpass()
 		);
 		
 		// We want to use an updater => gotta create one:

--- a/examples/multiple_queues/source/multiple_queues.cpp
+++ b/examples/multiple_queues/source/multiple_queues.cpp
@@ -56,7 +56,7 @@ public:
 			fragment_shader("shaders/color.frag"),											// Add a fragment shader
 			cfg::front_face::define_front_faces_to_be_clockwise(),							// Front faces are in clockwise order
 			cfg::viewport_depth_scissors_config::from_framebuffer(avk::context().main_window()->backbuffer_reference_at_index(0)), // Align viewport with main window's resolution
-			avk::context().main_window()->renderpass()
+			avk::context().main_window()->get_renderpass()
 		);
 
 		// Create vertex buffers --- namely one for each frame in flight.

--- a/examples/present_from_compute/source/present_from_compute.cpp
+++ b/examples/present_from_compute/source/present_from_compute.cpp
@@ -56,7 +56,7 @@ public:
 			avk::fragment_shader("shaders/color.frag"),											// Add a fragment shader
 			avk::cfg::front_face::define_front_faces_to_be_clockwise(),							// Front faces are in clockwise order
 			avk::cfg::viewport_depth_scissors_config::from_framebuffer(avk::context().main_window()->backbuffer_reference_at_index(0)), // Align viewport with main window's resolution
-			avk::context().main_window()->renderpass()
+			avk::context().main_window()->get_renderpass()
 		);
 
 		// Create compute pipeline:
@@ -82,7 +82,7 @@ public:
 								avk::on_store::store.in_layout(avk::layout::color_attachment_optimal)
 							)
 						},
-						mainWnd->renderpass()->subpass_dependencies() // Use the same as the main window's renderpass
+						mainWnd->get_renderpass()->subpass_dependencies() // Use the same as the main window's renderpass
 					),
 					avk::context().create_image_view(avk::context().create_image(mainWnd->resolution().x, mainWnd->resolution().y, mainWnd->swap_chain_image_format(), 1, avk::memory_usage::device, avk::image_usage::general_color_attachment | avk::image_usage::sampled | avk::image_usage::shader_storage))
 				)

--- a/examples/texture_cubemap/source/texture_cubemap.cpp
+++ b/examples/texture_cubemap/source/texture_cubemap.cpp
@@ -167,7 +167,7 @@ public: // v== avk::invokee overrides which will be invoked by the framework ==v
 			avk::cfg::viewport_depth_scissors_config::from_framebuffer(avk::context().main_window()->backbuffer_reference_at_index(0)),
 			// We'll render to the back buffer, which has a color attachment always, and in our case additionally a depth 
 			// attachment, which has been configured when creating the window. See main() function!
-			avk::context().main_window()->renderpass(), // Just use the same renderpass
+			avk::context().main_window()->get_renderpass(), // Just use the same renderpass
 			// The following define additional data which we'll pass to the pipeline:
 			avk::descriptor_binding(0, 0, mViewProjBufferSkybox),
 			avk::descriptor_binding(0, 1, mImageSamplerCubemap->as_combined_image_sampler(avk::layout::general))
@@ -186,7 +186,7 @@ public: // v== avk::invokee overrides which will be invoked by the framework ==v
 			avk::cfg::viewport_depth_scissors_config::from_framebuffer(avk::context().main_window()->backbuffer_reference_at_index(0)),
 			// We'll render to the back buffer, which has a color attachment always, and in our case additionally a depth 
 			// attachment, which has been configured when creating the window. See main() function!
-			avk::context().main_window()->renderpass(), // Just use the same renderpass
+			avk::context().main_window()->get_renderpass(), // Just use the same renderpass
 			// The following define additional data which we'll pass to the pipeline:
 			avk::descriptor_binding(0, 0, mViewProjBufferReflect),
 			avk::descriptor_binding(0, 1, mImageSamplerCubemap->as_combined_image_sampler(avk::layout::general))

--- a/examples/vertex_buffers/source/vertex_buffers.cpp
+++ b/examples/vertex_buffers/source/vertex_buffers.cpp
@@ -56,7 +56,7 @@ public:
 			avk::fragment_shader("shaders/color.frag"),											// Add a fragment shader
 			avk::cfg::front_face::define_front_faces_to_be_clockwise(),							// Front faces are in clockwise order
 			avk::cfg::viewport_depth_scissors_config::from_framebuffer(avk::context().main_window()->backbuffer_reference_at_index(0)), // Align viewport with main window's resolution
-			avk::context().main_window()->renderpass()
+			avk::context().main_window()->get_renderpass()
 		);
 
 		// Create vertex buffers --- namely one for each frame in flight.


### PR DESCRIPTION
All of a sudden, GCC does not allow a method named `renderpass` anymore.
window::renderpass() -> window::get_renderpass() to make it compile with GCC.
