### PR TITLE
Add missing template type specification - fix #181

### DIFF
--- a/auto_vk_toolkit/include/composition.hpp
+++ b/auto_vk_toolkit/include/composition.hpp
@@ -347,7 +347,9 @@ namespace avk
 
 #if !SINGLE_THREADED
 			// off it goes
-			std::thread renderThread(render_thread, this, std::move(aUpdateCallback), std::move(aRenderCallback));
+			std::thread renderThread(
+				render_thread<decltype(aUpdateCallback), decltype(aRenderCallback)>,
+				this, std::move(aUpdateCallback), std::move(aRenderCallback));
 #endif
 			
 			while (!mShouldStop)

--- a/examples/ray_query_in_ray_tracing_shaders/source/triangle_mesh_geometry_manager.hpp
+++ b/examples/ray_query_in_ray_tracing_shaders/source/triangle_mesh_geometry_manager.hpp
@@ -64,7 +64,7 @@ public: // v== avk::invokee overrides which will be invoked by the framework ==v
 					std::move(nrmCmds),
 					std::move(texCmds),
 					// Gotta wait until all buffers have been transfered before we can start the BLAS build:
-					avk::sync::global_memory_barrier(avk::stage::transfer >> avk::stage::acceleration_structure_build, avk::access::transfer_write >> avk::access::shader_read),
+					avk::sync::global_memory_barrier(avk::stage::transfer >> avk::stage::acceleration_structure_build, avk::access::transfer_write >> avk::access::acceleration_structure_read),
 					blas->build({ avk::vertex_index_buffer_pair{ posBfr, idxBfr } })
 				}, *mQueue)->wait_until_signalled();
 

--- a/examples/ray_tracing_with_shadows_and_ao/source/triangle_mesh_geometry_manager.hpp
+++ b/examples/ray_tracing_with_shadows_and_ao/source/triangle_mesh_geometry_manager.hpp
@@ -61,7 +61,7 @@ public: // v== avk::invokee overrides which will be invoked by the framework ==v
 					std::move(nrmCmds),
 					std::move(texCmds),
 					// Gotta wait until all buffers have been transfered before we can start the BLAS build:
-					avk::sync::global_memory_barrier(avk::stage::transfer >> avk::stage::acceleration_structure_build, avk::access::transfer_write >> avk::access::shader_read),
+					avk::sync::global_memory_barrier(avk::stage::transfer >> avk::stage::acceleration_structure_build, avk::access::transfer_write >> avk::access::acceleration_structure_read),
 					blas->build({ avk::vertex_index_buffer_pair{ posBfr, idxBfr } })
 					}, *mQueue)->wait_until_signalled();
 

--- a/visual_studio/examples/skinned_meshlets/skinned_meshlets.vcxproj
+++ b/visual_studio/examples/skinned_meshlets/skinned_meshlets.vcxproj
@@ -185,6 +185,7 @@
       </ForcedIncludeFiles>
       <TreatSpecificWarningsAsErrors>4715</TreatSpecificWarningsAsErrors>
       <PrecompiledHeaderFile>cg_stdafx.hpp</PrecompiledHeaderFile>
+      <AdditionalOptions>/bigobj %(AdditionalOptions)</AdditionalOptions>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
As described in the linked issue #181 this fixes the compilation problem. Included is also the commit which adds `\bigobj` command line option to `skinned_meshlets` project. 
Edit: 
Uh Github apparently allows creating multiple PRs only by creating multiple branches, I did not know that... Included is also partial fix for #182. It is only partial because the second part of the fix is included in [this](https://github.com/cg-tuwien/Auto-Vk/pull/91). 

I have no idea how submodules work with PR changes so to be sure I've split this into a PR for this repo and PR for Auto-Vk, hope it's okay...