### PR TITLE
fixed exceptiton capture - now by const & instead of value

### DIFF
--- a/auto_vk_toolkit/src/window.cpp
+++ b/auto_vk_toolkit/src/window.cpp
@@ -533,7 +533,7 @@ namespace avk
 				// swap chain will be recreated in the next frame
 			}
 		}
-		catch (vk::OutOfDateKHRError omg) {
+		catch (const vk::OutOfDateKHRError & omg) {
 			LOG_INFO(std::format("Swap chain out of date in render_frame. Reason[{}] in frame#{}. Going to recreate it...", omg.what(), current_frame()));
 			mResourceRecreationDeterminator.set_recreation_required_for(recreation_determinator::reason::invalid_swap_chain);
 			// Just do nothing. Ignore the failure. This frame is lost.


### PR DESCRIPTION
The swapchain out of date error was previously being captured by value which causes crash when compiling with clang. This fixes it by capturing the exception by const reference.